### PR TITLE
Expose ACL path as static

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -92,4 +92,8 @@ module.exports = function(schema, options) {
 
         return cursor;
     };
+
+    schema.statics.getAclPath = function() {
+        return options.path;
+    };
 };

--- a/test/test_object.js
+++ b/test/test_object.js
@@ -134,4 +134,10 @@ describe('Object', function() {
             assert.ok(model.isModified('_acl'));
         });
     });
+
+    describe('when getting ACL path', function() {
+        it('returns the correct path', function() {
+            assert.deepEqual(Test.getAclPath(), '_acl');
+        });
+    });
 });


### PR DESCRIPTION
I've had the need numerous times to refer the `_acl` path outside of the plugin. This just exposes it so I don't have to hard code.
